### PR TITLE
Fix conversation clearing refresh

### DIFF
--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -280,7 +280,8 @@ def main():
             if 'messages' in st.session_state:
                 st.session_state.messages = []
             st.success("Conversation cleared!")
-            st.rebalance()
+            # Refresh the page to ensure the sidebar state resets
+            st.rerun()
         
         # Export conversation
         if st.button("💾 Export Conversation"):


### PR DESCRIPTION
## Summary
- fix conversation clearing so sidebar state resets by calling `st.rerun()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591b3423ac8321ba8c86c7b079709b